### PR TITLE
Add Event Index

### DIFF
--- a/Graffle.FlowSdk.Services/Models/FlowTransactionResponseEvent.cs
+++ b/Graffle.FlowSdk.Services/Models/FlowTransactionResponseEvent.cs
@@ -29,6 +29,6 @@ namespace Graffle.FlowSdk.Services.Models
         public string BlockId { get; }
         public string Type { get; }
 
-        public uint EventIndex{get;}
+        public uint EventIndex { get; }
     }
 }

--- a/Graffle.FlowSdk.Services/Models/FlowTransactionResponseEvent.cs
+++ b/Graffle.FlowSdk.Services/Models/FlowTransactionResponseEvent.cs
@@ -21,7 +21,6 @@ namespace Graffle.FlowSdk.Services.Models
             this.EventIndex = @event.EventIndex;
 
         }
-
         public string TransactionId { get; }
         public string Payload { get; }
         public GraffleCompositeType EventComposite { get; }

--- a/Graffle.FlowSdk.Services/Models/FlowTransactionResponseEvent.cs
+++ b/Graffle.FlowSdk.Services/Models/FlowTransactionResponseEvent.cs
@@ -20,7 +20,7 @@ namespace Graffle.FlowSdk.Services.Models
             this.Type = @event.Type;
             this.EventIndex = @event.EventIndex;
         }
-        
+
         public string TransactionId { get; }
         public string Payload { get; }
         public GraffleCompositeType EventComposite { get; }

--- a/Graffle.FlowSdk.Services/Models/FlowTransactionResponseEvent.cs
+++ b/Graffle.FlowSdk.Services/Models/FlowTransactionResponseEvent.cs
@@ -18,6 +18,8 @@ namespace Graffle.FlowSdk.Services.Models
             this.TransactionIndex = @event.TransactionIndex;
             this.BlockId = blockId.ToHash();
             this.Type = @event.Type;
+            this.EventIndex = @event.EventIndex;
+
         }
 
         public string TransactionId { get; }
@@ -26,5 +28,7 @@ namespace Graffle.FlowSdk.Services.Models
         public uint TransactionIndex { get; }
         public string BlockId { get; }
         public string Type { get; }
+
+        public uint EventIndex{get;}
     }
 }

--- a/Graffle.FlowSdk.Services/Models/FlowTransactionResponseEvent.cs
+++ b/Graffle.FlowSdk.Services/Models/FlowTransactionResponseEvent.cs
@@ -19,8 +19,8 @@ namespace Graffle.FlowSdk.Services.Models
             this.BlockId = blockId.ToHash();
             this.Type = @event.Type;
             this.EventIndex = @event.EventIndex;
-
         }
+        
         public string TransactionId { get; }
         public string Payload { get; }
         public GraffleCompositeType EventComposite { get; }

--- a/Graffle.FlowSdk.Services/Models/FlowTransactionResult.cs
+++ b/Graffle.FlowSdk.Services/Models/FlowTransactionResult.cs
@@ -14,7 +14,7 @@ namespace Graffle.FlowSdk.Services.Models
         uint StatusCode { get; }
         IList<FlowTransactionResponseEvent> Events { get; }
     }
-    
+
     public class FlowTransactionResult : IFlowTransactionResult
     {
         public FlowTransactionResult(Flow.Access.TransactionResultResponse flowTransactionResponse)


### PR DESCRIPTION
Events on transactions were missing the event index used to mark them as unique.