### PR TITLE
fix issue with primitive types in arrays

### DIFF
--- a/Graffle.FlowSdk.Services/Graffle.FlowSdk.Services.csproj
+++ b/Graffle.FlowSdk.Services/Graffle.FlowSdk.Services.csproj
@@ -19,6 +19,6 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.22" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.20" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Graffle.FlowSdk" Version="0.1.6-prerelease" />
+    <PackageReference Include="Graffle.FlowSdk" Version="0.1.8-prerelease" />
   </ItemGroup>
 </Project>

--- a/Graffle.FlowSdk.Services/Serialization/GraffleCompositeTypeConverter.cs
+++ b/Graffle.FlowSdk.Services/Serialization/GraffleCompositeTypeConverter.cs
@@ -68,9 +68,8 @@ namespace System.Text.Json
                         var result = new List<object>();
                         foreach (var arrayField in arrayFields)
                         {
-                            var arrayFieldRoot = JsonDocument.Parse(arrayField.Values.Last());
-                            var arrayFieldRootType = arrayFieldRoot.RootElement.ValueKind;
-                            if (arrayFieldRootType != JsonValueKind.Object)
+                            var type = arrayField.Values.First();
+                            if (FlowValueType.IsPrimitiveType(type))
                             {
                                 // This is a hack to put back together primitives in an array.
                                 var x = arrayField.Values.First();
@@ -83,6 +82,7 @@ namespace System.Text.Json
                             else
                             {
                                 // dealing with a recursive complex type
+                                var arrayFieldRoot = JsonDocument.Parse(arrayField.Values.Last());
                                 var arrayFieldRootElements = arrayFieldRoot.RootElement.EnumerateObject().ToDictionary(x => x.Name, x => x.Value);
                                 if (arrayFieldRootElements.ContainsKey("fields"))
                                 {


### PR DESCRIPTION
Arrays with primitive types is throwing an exception when deserializing - JsonDocument.Parse will throw since the primitve value is not valid json

Will increment version # for this repo in an upcoming PR