### PR TITLE
Feature/array with struct serialization

### DIFF
--- a/Graffle.FlowSdk.Services.Tests/SerializationTests/GraffleCompositeTypeConverterTests.cs
+++ b/Graffle.FlowSdk.Services.Tests/SerializationTests/GraffleCompositeTypeConverterTests.cs
@@ -314,6 +314,80 @@ namespace Graffle.FlowSdk.Services.Tests.SerializationTests
         }
 
         [TestMethod]
+        public void DeserializeFlowCadence_ArrayType_ContainsPathTypeAndCapabilityType_ReturnsGraffleCompositeType()
+        {
+            /*
+            {
+                "type":"Array",
+                "value": [
+                    {
+                        "type":"Path",
+                        "value": {
+                            "domain":"storage",
+                            "identifier":"pathId"
+                        }
+                    },
+                    {
+                        "type":"Type",
+                        "value": {
+                            "staticType": "staticTypeValue"
+                        }
+                    },
+                    {
+                        "type":"Capability",
+                        "value": {
+                            "path": "/public/someInteger",
+                            "address": "0x1",
+                            "borrowType": "Int"
+                        }
+                    }
+                ]
+            }
+            */
+
+            var json = @"{""type"":""Array"",""value"":[{""type"":""Path"",""value"":{""domain"":""storage"",""identifier"":""pathId""}},{""type"":""Type"",""value"":{""staticType"":""staticTypeValue""}},{""type"":""Capability"",""value"":{""path"":""/public/someInteger"",""address"":""0x1"",""borrowType"":""Int""}}]}";
+            var field = CreateField("testField", json);
+            var fields = new List<Dictionary<string, string>>() { field };
+
+            var converter = new GraffleCompositeTypeConverter();
+            var result = converter.DeserializeFlowCadence("testId", "event", fields);
+
+            //verify GraffleComposite data
+            var data = result.Data;
+            Assert.AreEqual(1, data.Count);
+            var arrayField = data["testField"];
+            Assert.IsInstanceOfType(arrayField, typeof(List<object>));
+
+            var parsedArray = arrayField as List<object>;
+            Assert.AreEqual(3, parsedArray.Count);
+
+            //check individual values
+            var path = parsedArray[0];
+            Assert.IsInstanceOfType(path, typeof(Dictionary<string, string>));
+            var pathDict = path as Dictionary<string, string>;
+            Assert.AreEqual(2, pathDict.Count);
+            Assert.IsTrue(pathDict.ContainsKey("domain"));
+            Assert.AreEqual("storage", pathDict["domain"]);
+            Assert.IsTrue(pathDict.ContainsKey("identifier"));
+            Assert.AreEqual("pathId", pathDict["identifier"]);
+
+            var type = parsedArray[1];
+            Assert.IsInstanceOfType(type, typeof(string));
+            Assert.AreEqual("staticTypeValue", type);
+
+            var capability = parsedArray[2];
+            Assert.IsInstanceOfType(capability, typeof(Dictionary<string, string>));
+            var capabilityDict = capability as Dictionary<string, string>;
+            Assert.AreEqual(3, capabilityDict.Count);
+            Assert.IsTrue(capabilityDict.ContainsKey("path"));
+            Assert.AreEqual("/public/someInteger", capabilityDict["path"]);
+            Assert.IsTrue(capabilityDict.ContainsKey("address"));
+            Assert.AreEqual("0x1", capabilityDict["address"]);
+            Assert.IsTrue(capabilityDict.ContainsKey("borrowType"));
+            Assert.AreEqual("Int", capabilityDict["borrowType"]);
+        }
+
+        [TestMethod]
         public void Write_ThrowsNotImplementedException()
         {
             var converter = new GraffleCompositeTypeConverter();

--- a/Graffle.FlowSdk.Services.Tests/SerializationTests/GraffleCompositeTypeConverterTests.cs
+++ b/Graffle.FlowSdk.Services.Tests/SerializationTests/GraffleCompositeTypeConverterTests.cs
@@ -207,26 +207,19 @@ namespace Graffle.FlowSdk.Services.Tests.SerializationTests
             //verify array values
             Assert.AreEqual(2, value.Count);
             Assert.AreEqual((uint)12345, value[0]);
-            Assert.IsInstanceOfType(value[1], typeof(GraffleCompositeType));
-
-            //verify struct
-            var composite = value[1] as GraffleCompositeType;
-            Assert.AreEqual("structId", composite.Id);
-            Assert.AreEqual("Struct", composite.Type);
+            Assert.IsInstanceOfType(value[1], typeof(Dictionary<string, object>));
 
             //verify struct fields
-            Assert.IsInstanceOfType(composite.Data, typeof(Dictionary<string, object>));
+            var composite = value[1] as Dictionary<string, object>;
+            Assert.AreEqual(2, composite.Keys.Count);
 
-            var structFields = composite.Data as Dictionary<string, object>;
-            Assert.AreEqual(2, structFields.Keys.Count);
-
-            var first = structFields.Keys.First();
+            var first = composite.Keys.First();
             Assert.AreEqual("structField1", first);
-            Assert.AreEqual("structStringValue", structFields[first]);
+            Assert.AreEqual("structStringValue", composite[first]);
 
-            var second = structFields.Keys.Skip(1).First();
+            var second = composite.Keys.Skip(1).First();
             Assert.AreEqual(second, "structField2");
-            Assert.AreEqual((long)5432, structFields[second]);
+            Assert.AreEqual((long)5432, composite[second]);
         }
 
         [TestMethod]

--- a/Graffle.FlowSdk.Services.Tests/TransactionTests/TransactionResponsesTests.cs
+++ b/Graffle.FlowSdk.Services.Tests/TransactionTests/TransactionResponsesTests.cs
@@ -216,12 +216,32 @@ namespace Graffle.FlowSdk.Services.Tests.TransactionsTests
         }
 
         [TestMethod]
-        public async Task t()
+        public async Task Serialize_ArrayContainsStructs_OnlyStructFieldsAreSerialized()
         {
-            var res = await GetTransaction(58869074, "e013f514bf38c8eebb2aa01a7e9d6d1b09f2b4ebff18e7e94013e6e01fc95889");
+            var res = await GetTransaction(24684541, "c6043a12ddab4740d6dbb27a9171062813b0fff05f0a03529c61c620311be8e4", NodeType.MainNet);
             var events = res.Events;
-            var ev = events.FirstOrDefault(ev => ev.Type == "A.05a26c163795266b.BallerzSimz.SimCompleted");
+            var ev = events.FirstOrDefault(ev => ev.Type == "A.8b148183c28ff88f.GaiaOrder.OrderAvailable");
             var composite = ev.EventComposite;
+
+            Assert.IsNotNull(composite);
+            var compositeData = composite.Data;
+            Assert.IsNotNull(composite.Data);
+
+            //verify that *only* the struct's fields were serialized
+            var arrayData = compositeData["payments"];
+            Assert.IsNotNull(arrayData);
+            Assert.IsInstanceOfType(arrayData, typeof(List<object>));
+
+            //check items in the array
+            //these should be dictionaries (ie struct fields) rather than GraffleCompositeType
+            foreach (var obj in arrayData)
+            {
+                Assert.IsInstanceOfType(obj, typeof(Dictionary<string, object>));
+            }
+
+            //let's take a look at one
+            var structFields = arrayData[0] as Dictionary<string, object>;
+            Assert.AreEqual(4, structFields.Count);
         }
 
         private async Task<FlowTransactionResult> GetTransaction(ulong blockHeight, string transactionId, NodeType nodeType = NodeType.TestNet)

--- a/Graffle.FlowSdk.Services/Graffle.FlowSdk.Services.csproj
+++ b/Graffle.FlowSdk.Services/Graffle.FlowSdk.Services.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>0.1.20-prerelease</Version>
+    <Version>0.1.21-prerelease</Version>
     <PackageDescription>Sdk and additional services for interacting with the Flow blockchain.</PackageDescription>
     <RepositoryUrl>https://github.com/Graffle/flow-c-sharp-graffle-sdk</RepositoryUrl>
     <Company>Graffle Labs Inc.</Company>

--- a/Graffle.FlowSdk.Services/Serialization/GraffleCompositeTypeConverter.cs
+++ b/Graffle.FlowSdk.Services/Serialization/GraffleCompositeTypeConverter.cs
@@ -84,6 +84,7 @@ namespace System.Text.Json
                                 }
                                 else
                                 {
+                                    //value here is a json object instead of a primitive value
                                     z = $"{{\"type\":\"{x}\",\"value\":{y}}}";
                                 }
 

--- a/Graffle.FlowSdk.Services/Serialization/GraffleCompositeTypeConverter.cs
+++ b/Graffle.FlowSdk.Services/Serialization/GraffleCompositeTypeConverter.cs
@@ -85,11 +85,14 @@ namespace System.Text.Json
                                 var arrayFieldRootElements = arrayFieldRoot.RootElement.EnumerateObject().ToDictionary(x => x.Name, x => x.Value);
                                 if (arrayFieldRootElements.ContainsKey("fields"))
                                 {
+                                    //composite type ie struct, resource, event, etc
                                     var arrayItemId = arrayFieldRootElements.FirstOrDefault(z => z.Key == "id").Value.ToString();
                                     var arrayItemType = arrayField.FirstOrDefault().Value.ToString();
                                     var singleComplexFields = arrayFieldRootElements.FirstOrDefault(z => z.Key == "fields").Value.EnumerateArray().Select(h => h.EnumerateObject().ToDictionary(n => n.Name, n => n.Value.ToString()));
                                     var newItem = DeserializeFlowCadence(arrayItemId, arrayItemType, singleComplexFields);
-                                    result.Add(newItem);
+
+                                    //only add the composite type's data to the array
+                                    result.Add(newItem.Data);
                                 }
                                 else if (arrayFieldRootElements.ContainsKey("staticType"))
                                 {

--- a/Graffle.FlowSdk.Services/Serialization/GraffleCompositeTypeConverter.cs
+++ b/Graffle.FlowSdk.Services/Serialization/GraffleCompositeTypeConverter.cs
@@ -68,12 +68,25 @@ namespace System.Text.Json
                         foreach (var arrayField in arrayFields)
                         {
                             var type = arrayField.Values.First();
-                            if (FlowValueType.IsPrimitiveType(type))
+                            bool isPrimitive = FlowValueType.IsPrimitiveType(type);
+                            if (FlowValueType.IsPrimitiveType(type)
+                                || type == "Path"
+                                || type == "Capability"
+                                || type == "Type")
                             {
                                 // This is a hack to put back together primitives in an array.
                                 var x = arrayField.Values.First();
                                 var y = arrayField.Values.Last();
-                                var z = $"{{\"type\":\"{x}\",\"value\":\"{y}\"}}";
+                                string z;
+                                if (isPrimitive)
+                                {
+                                    z = $"{{\"type\":\"{x}\",\"value\":\"{y}\"}}";
+                                }
+                                else
+                                {
+                                    z = $"{{\"type\":\"{x}\",\"value\":{y}}}";
+                                }
+
                                 dynamic primitiveValue = FlowValueType.CreateFromCadence(z);
                                 var data = primitiveValue.Data;
                                 result.Add(data);
@@ -83,22 +96,15 @@ namespace System.Text.Json
                                 // dealing with a recursive complex type
                                 var arrayFieldRoot = JsonDocument.Parse(arrayField.Values.Last());
                                 var arrayFieldRootElements = arrayFieldRoot.RootElement.EnumerateObject().ToDictionary(x => x.Name, x => x.Value);
-                                if (arrayFieldRootElements.ContainsKey("fields"))
-                                {
-                                    //composite type ie struct, resource, event, etc
-                                    var arrayItemId = arrayFieldRootElements.FirstOrDefault(z => z.Key == "id").Value.ToString();
-                                    var arrayItemType = arrayField.FirstOrDefault().Value.ToString();
-                                    var singleComplexFields = arrayFieldRootElements.FirstOrDefault(z => z.Key == "fields").Value.EnumerateArray().Select(h => h.EnumerateObject().ToDictionary(n => n.Name, n => n.Value.ToString()));
-                                    var newItem = DeserializeFlowCadence(arrayItemId, arrayItemType, singleComplexFields);
 
-                                    //only add the composite type's data to the array
-                                    result.Add(newItem.Data);
-                                }
-                                else if (arrayFieldRootElements.ContainsKey("staticType"))
-                                {
-                                    var arrayItemId = arrayFieldRootElements.FirstOrDefault(z => z.Key == "staticType").Value.ToString();
-                                    result.Add(arrayItemId);
-                                }
+                                //composite type ie struct, resource, event, etc
+                                var arrayItemId = arrayFieldRootElements.FirstOrDefault(z => z.Key == "id").Value.ToString();
+                                var arrayItemType = arrayField.FirstOrDefault().Value.ToString();
+                                var singleComplexFields = arrayFieldRootElements.FirstOrDefault(z => z.Key == "fields").Value.EnumerateArray().Select(h => h.EnumerateObject().ToDictionary(n => n.Name, n => n.Value.ToString()));
+                                var newItem = DeserializeFlowCadence(arrayItemId, arrayItemType, singleComplexFields);
+
+                                //only add the composite type's data to the array
+                                result.Add(newItem.Data);
                             }
                         }
                         compositeType.Data[item.Values.First().ToCamelCase()] = result;


### PR DESCRIPTION
Resolving two issues here with ArrayType

* When an array contains a Struct we were serializing all of the stuct json - fix is to just add the struct's fields to the dictionary
* When an array type contains CapabilityType or PathType these were simply not being serialized - fixed this