### PR TITLE
Bugfix/nested flow vlaue types

### DIFF
--- a/Graffle.FlowSdk.Services.Tests/BlockTests/BlockHeightTests.cs
+++ b/Graffle.FlowSdk.Services.Tests/BlockTests/BlockHeightTests.cs
@@ -9,7 +9,6 @@ using Graffle.FlowSdk.Services.Nodes;
 namespace Graffle.FlowSdk.Services.Tests.BlockTests
 {
     [TestClass]
-    [Ignore]
     public class BlockHeightTests
     {
         private IGraffleClient flowClient { get; }
@@ -68,15 +67,14 @@ namespace Graffle.FlowSdk.Services.Tests.BlockTests
         }
 
         [TestMethod]
-        [Ignore]
         public async Task Ryan_Test()
         {
             var s = @"
-                        import NonFungibleToken from 0x1d7e57aa55817448
-                        import MetadataViews from 0x1d7e57aa55817448
-                        import FungibleToken from 0xf233dcee88fe0abe
-                        import FlowToken from 0x1654653399040a61
-                        import GoatedGoats from 0x2068315349bdfce5
+                        import NonFungibleToken from 0x631e88ae7f1d7c20
+                        import MetadataViews from 0x631e88ae7f1d7c20
+                        import FungibleToken from 0x9a0766d93b6608b7
+                        import FlowToken from 0x7e60df042a9c0868
+                        import GoatedGoats from 0x386817f360a5c8df
 
                         pub fun main(id: UInt64, address: Address): {String: AnyStruct} {
                             let account = getAccount(address)
@@ -95,11 +93,11 @@ namespace Graffle.FlowSdk.Services.Tests.BlockTests
                             }
                         ";
 
-            var factory = new FlowClientFactory(NodeType.MainNet);
+            var factory = new FlowClientFactory(NodeType.TestNet);
             var fc = factory.CreateFlowClient();
 
-            var arg1 = new UInt64Type(8243);
-            var arg2 = new AddressType("0x8a02f31896be25f9");
+            var arg1 = new UInt64Type(1392);
+            var arg2 = new AddressType("0x0f347531750c6f15");
 
             var scriptBytes = Encoding.ASCII.GetBytes(s);
             var latestBlock = await fc.GetLatestBlockAsync();
@@ -114,6 +112,13 @@ namespace Graffle.FlowSdk.Services.Tests.BlockTests
 
             var resTest = System.Text.Json.JsonSerializer.Deserialize<FlowValueType>(metaDataJson, options);
             Assert.IsInstanceOfType(resTest, typeof(DictionaryType));
+
+            var dict = resTest as DictionaryType;
+            var ser = dict.ConvertToObject();
+
+            var x = new { Prop = ser };
+
+            var json = System.Text.Json.JsonSerializer.Serialize(x);
         }
     }
 }

--- a/Graffle.FlowSdk.Services.Tests/BlockTests/BlockHeightTests.cs
+++ b/Graffle.FlowSdk.Services.Tests/BlockTests/BlockHeightTests.cs
@@ -67,6 +67,7 @@ namespace Graffle.FlowSdk.Services.Tests.BlockTests
         }
 
         [TestMethod]
+        [Ignore]
         public async Task Ryan_Test()
         {
             var s = @"

--- a/Graffle.FlowSdk.Services.Tests/ExtensionTests/ArrayTypeExtensionTests.cs
+++ b/Graffle.FlowSdk.Services.Tests/ExtensionTests/ArrayTypeExtensionTests.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Graffle.FlowSdk.Services.Extensions;
+using Graffle.FlowSdk.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+
+namespace Graffle.FlowSdk.Services.Tests.ExtensionTests
+{
+    [TestClass]
+    public class ArrayExtensionsTests
+    {
+        [TestMethod]
+        public void ToValueData_PrimitiveValues_ReturnsList()
+        {
+            var intType = new Int16Type(123);
+            var ufix64Type = new UFix64Type(2345.6m);
+            var arrayType = new ArrayType(new List<FlowValueType>() { intType, ufix64Type });
+
+            var result = arrayType.ToValueData();
+            Assert.IsInstanceOfType(result, typeof(List<object>));
+
+            var list = result as List<object>;
+            Assert.AreEqual(2, list.Count);
+
+            Assert.AreEqual(intType.Data, list[0]);
+            Assert.AreEqual(ufix64Type.Data, list[1]);
+        }
+
+        [TestMethod]
+        public void ToValueData_NestedArray_ReturnsList()
+        {
+            var intType = new Int16Type(123);
+            var ufix64Type = new UFix64Type(2345.6m);
+            var innerArrayType = new ArrayType(new List<FlowValueType>() { intType, ufix64Type });
+
+            //arraytype with nested arraytype
+            var outerArrayType = new ArrayType(new List<FlowValueType>() { innerArrayType });
+
+            var result = outerArrayType.ToValueData();
+            Assert.IsInstanceOfType(result, typeof(List<object>));
+
+            var list = result as List<object>;
+            Assert.AreEqual(1, list.Count);
+
+            //pull out the outer array
+            var item = list.First();
+            Assert.IsInstanceOfType(item, typeof(List<object>));
+
+            //pull out the inner array
+            //here we are verifying that the list *does not* contain FlowValueType
+            var innerList = item as List<object>;
+            Assert.AreEqual(2, innerList.Count);
+
+            foreach (var x in innerList)
+            {
+                Assert.IsNotInstanceOfType(x, typeof(FlowValueType));
+            }
+
+            Assert.AreEqual(intType.Data, innerList[0]);
+            Assert.AreEqual(ufix64Type.Data, innerList[1]);
+        }
+
+        [TestMethod]
+        public void ToValueData_NestedDictionary_ReturnsList()
+        {
+            var intType = new Int16Type(123);
+            var ufix64Type = new UFix64Type(2345.6m);
+            var dictionaryType = new DictionaryType();
+            dictionaryType.Data.Add(intType, ufix64Type);
+
+            //nest this dictionary inside of an array
+            var arrayType = new ArrayType(new List<FlowValueType>() { dictionaryType });
+
+            var result = arrayType.ToValueData();
+            Assert.IsInstanceOfType(result, typeof(List<object>));
+
+            var list = result as List<object>;
+            Assert.AreEqual(1, list.Count());
+
+            //pull out the nested dictionary 
+            var item = list.First();
+            Assert.IsNotInstanceOfType(item, typeof(FlowValueType)); //should NOT be FlowValueType
+
+            Assert.IsInstanceOfType(item, typeof(Dictionary<object, object>));
+            var dict = item as Dictionary<object, object>;
+
+            Assert.AreEqual(1, dict.Keys.Count);
+
+            var dictItem = dict.First();
+            Assert.AreEqual(intType.Data.ToString(), dictItem.Key); //key gets converted to string
+            Assert.AreEqual(ufix64Type.Data, dictItem.Value);
+
+            Assert.IsNotInstanceOfType(dictItem.Key, typeof(FlowValueType));
+            Assert.IsNotInstanceOfType(dictItem.Value, typeof(FlowValueType));
+        }
+
+        [TestMethod]
+        public void ToValueData_NestedStruct_ReturnsList()
+        {
+            var intType = new Int16Type(123);
+            var ufix64Type = new UFix64Type(2345.6m);
+            var intField = new CompositeField("intField", intType);
+            var ufixField = new CompositeField("ufixField", ufix64Type);
+
+            var composite = new CompositeType("Struct", "structId", new List<CompositeField>() { intField, ufixField });
+
+            //nest the composite inside of the array
+            var arrayType = new ArrayType(new List<FlowValueType>() { composite });
+
+            var result = arrayType.ToValueData();
+            Assert.IsInstanceOfType(result, typeof(List<object>));
+
+            var list = result as List<object>;
+            Assert.AreEqual(1, list.Count);
+
+            var item = list.First();
+            Assert.IsInstanceOfType(item, typeof(Dictionary<string, object>)); //this should be a dictionary, ie its the struct's fields
+
+            //verify the struct fields are in this dictionary
+            var dict = item as Dictionary<string, object>;
+            Assert.AreEqual(2, dict.Keys.Count);
+
+            var first = dict.First();
+            Assert.AreEqual("intField", first.Key);
+            Assert.AreEqual(intType.Data, first.Value);
+
+            var second = dict.Skip(1).First();
+            Assert.AreEqual("ufixField", second.Key);
+            Assert.AreEqual(ufix64Type.Data, second.Value);
+        }
+    }
+}

--- a/Graffle.FlowSdk.Services.Tests/ExtensionTests/DictionaryTypeExtensionTests.cs
+++ b/Graffle.FlowSdk.Services.Tests/ExtensionTests/DictionaryTypeExtensionTests.cs
@@ -95,5 +95,84 @@ namespace Graffle.FlowSdk.Services.Tests.ExtensionTests
             Assert.IsInstanceOfType(second.Value, typeof(string));
             Assert.AreEqual(stringField.Data, second.Value);
         }
+
+        [TestMethod]
+        public void ConvertToObject_NestedArray_ReturnsDictionary()
+        {
+            var intType = new IntType(123);
+            var stringType = new StringType("hello world");
+            var arrayType = new ArrayType(new List<FlowValueType>() { intType, stringType });
+
+            var dictKey = new StringType("dictionary KEY");
+
+            var dictionaryType = new DictionaryType();
+            dictionaryType.Data.Add(dictKey, arrayType);
+
+            var result = dictionaryType.ConvertToObject();
+            Assert.IsInstanceOfType(result, typeof(Dictionary<object, object>));
+            var dict = result as Dictionary<object, object>;
+
+            Assert.AreEqual(1, dict.Keys.Count);
+
+            var item = dict.First();
+            var key = item.Key;
+            Assert.IsInstanceOfType(key, typeof(string)); //string ie not FlowValueType
+            Assert.AreEqual(dictKey.Data, key);
+
+            var value = item.Value;
+            Assert.IsInstanceOfType(value, typeof(List<object>)); //dict key should be a list and not ArrayType
+
+            var list = value as List<object>;
+            Assert.AreEqual(2, list.Count);
+
+            //need to verify that there are primitives in here and not FlowValueType objects
+            var first = list[0];
+            Assert.IsInstanceOfType(first, typeof(int));
+            Assert.AreEqual(intType.Data, first);
+
+            var second = list[1];
+            Assert.IsInstanceOfType(second, typeof(string));
+            Assert.AreEqual(stringType.Data, second);
+        }
+
+        [TestMethod]
+        public void ConvertToObject_NestedDictionary_ReturnsDictionary() //yo dawg
+        {
+            var intType = new IntType(123);
+            var stringType = new StringType("hello world");
+            var innerDict = new DictionaryType();
+            innerDict.Data.Add(intType, stringType);
+
+            var dictKey = new StringType("dictionary KEY");
+            var outerDict = new DictionaryType();
+            outerDict.Data.Add(dictKey, innerDict);
+
+            var result = outerDict.ConvertToObject(); //basically need to verify that there are no FlowValueType objects in here
+
+            Assert.IsInstanceOfType(result, typeof(Dictionary<object, object>));
+            var dict = result as Dictionary<object, object>;
+
+            Assert.AreEqual(1, dict.Keys.Count);
+
+            var item = dict.First();
+            var key = item.Key;
+            Assert.IsInstanceOfType(key, typeof(string)); //string ie not FlowValueType
+            Assert.AreEqual(dictKey.Data, key);
+
+            //verify data
+            var value = item.Value;
+            Assert.IsInstanceOfType(value, typeof(Dictionary<object, object>));
+            var valueDict = value as Dictionary<object, object>;
+            Assert.AreEqual(1, valueDict.Keys.Count);
+
+            var innerItem = valueDict.First();
+            var innerKey = innerItem.Key;
+            Assert.IsInstanceOfType(innerKey, typeof(string));
+            Assert.AreEqual(intType.Data.ToString(), innerKey);
+
+            var innerValue = innerItem.Value;
+            Assert.IsInstanceOfType(innerValue, typeof(string));
+            Assert.AreEqual(stringType.Data, innerValue);
+        }
     }
 }

--- a/Graffle.FlowSdk.Services.Tests/Graffle.FlowSdk.Services.Tests.csproj
+++ b/Graffle.FlowSdk.Services.Tests/Graffle.FlowSdk.Services.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="coverlet.collector" Version="1.3.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.22" />
     <PackageReference Include="coverlet.msbuild" Version="3.1.2"/>
-    <PackageReference Include="Graffle.FlowSdk" Version="0.1.13-prerelease" />
+    <PackageReference Include="Graffle.FlowSdk" Version="0.1.14-prerelease" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Graffle.FlowSdk.Services/Extensions/ArrayTypeExtensions.cs
+++ b/Graffle.FlowSdk.Services/Extensions/ArrayTypeExtensions.cs
@@ -1,0 +1,38 @@
+using Graffle.FlowSdk.Types;
+using System.Collections.Generic;
+
+namespace Graffle.FlowSdk.Services.Extensions
+{
+    public static class ArrayExtensions
+    {
+        /// <summary>
+        /// Return array data as primitive types (string, int, etc) ie not objects of type FlowValueType
+        /// </summary>
+        /// <param name="x"></param>
+        /// <returns></returns>
+        public static List<dynamic> ToValueData(this ArrayType x)
+        {
+            var result = new List<dynamic>();
+            foreach (var item in x.Data)
+            {
+                if (FlowValueType.IsCompositeType(item.Type) && item is CompositeType composite) //complex type (struct, event), get the fields
+                {
+                    result.Add(composite.FieldsAsDictionary());
+                }
+                else if (item.Type == "Dictionary" && item is DictionaryType dictionary) //get the dictionary data as primitive values
+                {
+                    result.Add(dictionary.ConvertToObject());
+                }
+                else if (item.Type == "Array" && item is ArrayType arr) //nested array, need to recurse
+                {
+                    result.Add(arr.ToValueData());
+                }
+                else //primitive
+                {
+                    result.Add(((dynamic)item).Data); //primitive type, just add the Data directly
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/Graffle.FlowSdk.Services/Extensions/DictionaryTypeExtensions.cs
+++ b/Graffle.FlowSdk.Services/Extensions/DictionaryTypeExtensions.cs
@@ -1,13 +1,17 @@
+using Graffle.FlowSdk.Services.Extensions;
 using Graffle.FlowSdk.Types;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text.Json;
 
 namespace Graffle.FlowSdk.Services
 {
     public static class DictionaryTypeExtension
     {
-        public static dynamic ConvertToObject(this DictionaryType x)
+        /// <summary>
+        /// Return dictionary data as primitive types (string, int, etc) ie not objects of type FlowValueType
+        /// </summary>
+        /// <param name="x"></param>
+        /// <returns></returns>
+        public static Dictionary<dynamic, dynamic> ConvertToObject(this DictionaryType x)
         {
             var result = new Dictionary<dynamic, dynamic>();
             foreach (var item in x.Data)
@@ -17,14 +21,21 @@ namespace Graffle.FlowSdk.Services
 
                 var value = item.Value;
                 dynamic data;
-                if (FlowValueType.IsCompositeType(value.Type)) //nested composite type: struct, event, resource, etc
+                if (FlowValueType.IsCompositeType(value.Type) && value is CompositeType composite) //nested composite type: struct, event, resource, etc
                 {
-                    var composite = value as CompositeType;
                     data = composite.FieldsAsDictionary();
                 }
-                else //primitive
+                else if (value.Type == "Array" && value is ArrayType array) //nested array, need to get the values as primitive
                 {
-                    data = ((dynamic)item.Value).Data;
+                    data = array.ToValueData();
+                }
+                else if (value.Type == "Dictionary" && value is DictionaryType dictionary) //nested dictionary, need to recurse for primitive values
+                {
+                    data = dictionary.ConvertToObject();
+                }
+                else //primitive (int, string)
+                {
+                    data = ((dynamic)item.Value).Data; //primitive type, access the data directly
                 }
 
                 result[cleanedName] = data;

--- a/Graffle.FlowSdk.Services/Graffle.FlowSdk.Services.csproj
+++ b/Graffle.FlowSdk.Services/Graffle.FlowSdk.Services.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>0.1.26-prerelease</Version>
+    <Version>0.1.27-prerelease</Version>
     <PackageDescription>Sdk and additional services for interacting with the Flow blockchain.</PackageDescription>
     <RepositoryUrl>https://github.com/Graffle/flow-c-sharp-graffle-sdk</RepositoryUrl>
     <Company>Graffle Labs Inc.</Company>

--- a/Graffle.FlowSdk.Services/Graffle.FlowSdk.Services.csproj
+++ b/Graffle.FlowSdk.Services/Graffle.FlowSdk.Services.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.22" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.20" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Graffle.FlowSdk" Version="0.1.13-prerelease" />
+    <PackageReference Include="Graffle.FlowSdk" Version="0.1.14-prerelease" />
     <PackageReference Include="Polly" Version="7.2.3" />
   </ItemGroup>
 </Project>

--- a/Graffle.FlowSdk.Services/Serialization/FlowValueTypeConverter.cs
+++ b/Graffle.FlowSdk.Services/Serialization/FlowValueTypeConverter.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Serialization;
 using Graffle.FlowSdk.Types;
 using Graffle.FlowSdk;
 using Graffle.FlowSdk.Services;
+using Graffle.FlowSdk.Services.Extensions;
 
 namespace System.Text.Json
 {
@@ -59,7 +60,8 @@ namespace System.Text.Json
                 var result = (ArrayType)FlowValueType.CreateFromCadence("Array", rootElement.ToString());
                 return result;
             }
-            else if (rootType.GetString() == "Dictionary"){
+            else if (rootType.GetString() == "Dictionary")
+            {
                 var rootElement = rss.RootElement.ToString();
                 var result = (DictionaryType)FlowValueType.CreateFromCadence("Dictionary", rootElement.ToString());
                 return result;


### PR DESCRIPTION
Discovered a serialization issue with ArrayType containing DictionaryType and vice versa

Example:
```json
{
   "type":"Dictionary",
   "value":[
      {
         "key":{
            "type":"String",
            "value":"dictionary KEY"
         },
         "value":{
            "type":"Dictionary",
            "value":[
               {
                  "key":{
                     "type":"Int",
                     "value":"123"
                  },
                  "value":{
                     "type":"String",
                     "value":"hello world"
                  }
               }
            ]
         }
      }
   ]
}
```

prior to my changes here the inner dictionary data was getting serialized as FlowValueType instead of a dictionary full of primitive values