### PR TITLE
Fix concurrency issue with FlowClientFactorty's memorycache

### DIFF
--- a/Graffle.FlowSdk.Services/FlowClientFactory.cs
+++ b/Graffle.FlowSdk.Services/FlowClientFactory.cs
@@ -8,8 +8,8 @@ namespace Graffle.FlowSdk
 {
     public sealed class FlowClientFactory : IFlowClientFactory
     {
-        private static readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new ConcurrentDictionary<string, SemaphoreSlim>();
-        private static readonly MemoryCacheEntryOptions cacheEntryOptions = new MemoryCacheEntryOptions()
+        private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new ConcurrentDictionary<string, SemaphoreSlim>();
+        private readonly MemoryCacheEntryOptions cacheEntryOptions = new MemoryCacheEntryOptions()
                                                                .SetSlidingExpiration(TimeSpan.FromSeconds(60));
 
         private MemoryCache graffleClientCache = new MemoryCache(new MemoryCacheOptions());

--- a/Graffle.FlowSdk.Services/FlowClientFactory.cs
+++ b/Graffle.FlowSdk.Services/FlowClientFactory.cs
@@ -1,14 +1,19 @@
 using Graffle.FlowSdk.Services.Nodes;
 using Microsoft.Extensions.Caching.Memory;
 using System;
+using System.Collections.Concurrent;
+using System.Threading;
 
 namespace Graffle.FlowSdk
 {
     public sealed class FlowClientFactory : IFlowClientFactory
     {
-        private MemoryCache channelCache = new MemoryCache(new MemoryCacheOptions());
-        private readonly MemoryCacheEntryOptions cacheEntryOptions = new MemoryCacheEntryOptions()
-                                                       .SetAbsoluteExpiration(TimeSpan.FromSeconds(60));
+        private static readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new ConcurrentDictionary<string, SemaphoreSlim>();
+        private static readonly MemoryCacheEntryOptions cacheEntryOptions = new MemoryCacheEntryOptions()
+                                                               .SetSlidingExpiration(TimeSpan.FromSeconds(60));
+
+        private MemoryCache graffleClientCache = new MemoryCache(new MemoryCacheOptions());
+
         private readonly NodeType nodeType;
 
         public FlowClientFactory(NodeType nodeType)
@@ -111,12 +116,31 @@ namespace Graffle.FlowSdk
         /// <returns></returns>
         private IGraffleClient GenerateFlowClient(Spork spork)
         {
-            //Check to see if the channel already exists
-            var graffleClientFound = channelCache.TryGetValue(spork.Name, out GraffleClient graffleClient);
-            if (!graffleClientFound)
+            IGraffleClient graffleClient;
+
+            //check to see if a graffle client already exists for this spork in the cache
+            if (!graffleClientCache.TryGetValue(spork.Name, out graffleClient))
             {
-                graffleClient = new GraffleClient(spork);
-                channelCache.Set(spork.Name, graffleClient, cacheEntryOptions);
+                //don't have a client for this spork in the cache
+                //acquire lock so only one thread can insert into the cache
+                var myLock = _locks.GetOrAdd("lock", x => new SemaphoreSlim(1, 1));
+                myLock.Wait();
+
+                try
+                {
+                    //we got the lock
+                    //need to check the cache again because another thread may have inserted
+                    if (!graffleClientCache.TryGetValue(spork.Name, out graffleClient))
+                    {
+                        //still not here let's add it
+                        graffleClient = new GraffleClient(spork);
+                        graffleClientCache.Set(spork.Name, graffleClient, cacheEntryOptions);
+                    }
+                }
+                finally
+                {
+                    myLock.Release();
+                }
             }
 
             return graffleClient;

--- a/Graffle.FlowSdk.Services/FlowClientFactory.cs
+++ b/Graffle.FlowSdk.Services/FlowClientFactory.cs
@@ -10,7 +10,7 @@ namespace Graffle.FlowSdk
     {
         private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new ConcurrentDictionary<string, SemaphoreSlim>();
         private readonly MemoryCacheEntryOptions cacheEntryOptions = new MemoryCacheEntryOptions()
-                                                               .SetSlidingExpiration(TimeSpan.FromSeconds(60));
+                                                               .SetAbsoluteExpiration(TimeSpan.FromSeconds(60));
 
         private MemoryCache graffleClientCache = new MemoryCache(new MemoryCacheOptions());
 

--- a/Graffle.FlowSdk.Services/Graffle.FlowSdk.Services.csproj
+++ b/Graffle.FlowSdk.Services/Graffle.FlowSdk.Services.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>0.1.30-prerelease</Version>
+    <Version>0.1.31-prerelease</Version>
     <PackageDescription>Sdk and additional services for interacting with the Flow blockchain.</PackageDescription>
     <RepositoryUrl>https://github.com/Graffle/flow-c-sharp-graffle-sdk</RepositoryUrl>
     <Company>Graffle Labs Inc.</Company>


### PR DESCRIPTION
Minor concurrency issue here - in the multiple threads hitting `GenerateFlowClient` concurrently are all going to create new `IGraffleClient` instances and overwrite the other thread's work -- see https://docs.microsoft.com/en-us/dotnet/api/system.runtime.caching.memorycache.set?view=dotnet-plat-ext-6.0

Added a lock here when we are adding something to the cache so only one thread is doing it