### PR TITLE
fix serialization issue with composite types that contain optional types

### DIFF
--- a/Graffle.FlowSdk.Services.Tests/TransactionTests/TransactionResponsesTests.cs
+++ b/Graffle.FlowSdk.Services.Tests/TransactionTests/TransactionResponsesTests.cs
@@ -504,6 +504,25 @@ namespace Graffle.FlowSdk.Services.Tests.TransactionsTests
             Assert.AreEqual("A.ead892083b3e2c6c.DapperUtilityCoin.Vault", compositeData["ftVaultType"]);
         }
 
+        [TestMethod]
+        public async Task OptionalStruct_ContainsOptionalTypes()
+        {
+            var res = await GetTransaction(72067483, "39a8ed040c6060bf8f142d4fe12d1854c51aa72faf680a8087e3fb7e87c80260");
+
+            var ev = res.Events[1];
+
+            var composite = ev.EventComposite;
+
+            var nft = composite.Data["nft"] as Dictionary<string, object>;
+            Assert.IsNotNull(nft);
+
+            var collectionName = nft["collectionName"];
+            var collectionDescription = nft["collectionDescription"];
+
+            Assert.AreEqual("jambb", collectionName);
+            Assert.AreEqual("jambb FIND", collectionDescription);
+        }
+
         private async Task<FlowTransactionResult> GetTransaction(ulong blockHeight, string transactionId, NodeType nodeType = NodeType.TestNet)
         {
             //probably don't need all of these calls but lets do them anyways to ensure no exceptions are thrown

--- a/Graffle.FlowSdk.Services/Extensions/ArrayTypeExtensions.cs
+++ b/Graffle.FlowSdk.Services/Extensions/ArrayTypeExtensions.cs
@@ -15,22 +15,7 @@ namespace Graffle.FlowSdk.Services.Extensions
             var result = new List<dynamic>();
             foreach (var item in x.Data)
             {
-                if (FlowValueType.IsCompositeType(item.Type) && item is CompositeType composite) //complex type (struct, event), get the fields
-                {
-                    result.Add(composite.FieldsAsDictionary());
-                }
-                else if (item.Type == "Dictionary" && item is DictionaryType dictionary) //get the dictionary data as primitive values
-                {
-                    result.Add(dictionary.ConvertToObject());
-                }
-                else if (item.Type == "Array" && item is ArrayType arr) //nested array, need to recurse
-                {
-                    result.Add(arr.ToValueData());
-                }
-                else //primitive
-                {
-                    result.Add(((dynamic)item).Data); //primitive type, just add the Data directly
-                }
+                result.Add(FlowValueTypeUtility.FlowTypeToPrimitive(item));
             }
             return result;
         }

--- a/Graffle.FlowSdk.Services/Extensions/CompositeTypeExtensions.cs
+++ b/Graffle.FlowSdk.Services/Extensions/CompositeTypeExtensions.cs
@@ -18,25 +18,7 @@ namespace Graffle.FlowSdk.Services
                     f =>
                     {
                         var value = f.Value;
-                        dynamic result;
-                        if (FlowValueType.IsCompositeType(value.Type) && value is CompositeType composite)
-                        {
-                            result = composite.FieldsAsDictionary();
-                        }
-                        else if (value.Type == "Array" && value is ArrayType array)
-                        {
-                            result = array.ToValueData();
-                        }
-                        else if (value.Type == "Dictionary" && value is DictionaryType dict)
-                        {
-                            result = dict.ConvertToObject();
-                        }
-                        else //primitive
-                        {
-                            result = ((dynamic)f.Value).Data; //primitive value, just return the data directly
-                        }
-
-                        return result;
+                        return FlowValueTypeUtility.FlowTypeToPrimitive(value);
                     });
         }
     }

--- a/Graffle.FlowSdk.Services/Extensions/DictionaryTypeExtensions.cs
+++ b/Graffle.FlowSdk.Services/Extensions/DictionaryTypeExtensions.cs
@@ -20,23 +20,7 @@ namespace Graffle.FlowSdk.Services
                 var cleanedName = propertyName.ToCamelCase();
 
                 var value = item.Value;
-                dynamic data;
-                if (FlowValueType.IsCompositeType(value.Type) && value is CompositeType composite) //nested composite type: struct, event, resource, etc
-                {
-                    data = composite.FieldsAsDictionary();
-                }
-                else if (value.Type == "Array" && value is ArrayType array) //nested array, need to get the values as primitive
-                {
-                    data = array.ToValueData();
-                }
-                else if (value.Type == "Dictionary" && value is DictionaryType dictionary) //nested dictionary, need to recurse for primitive values
-                {
-                    data = dictionary.ConvertToObject();
-                }
-                else //primitive (int, string)
-                {
-                    data = ((dynamic)item.Value).Data; //primitive type, access the data directly
-                }
+                dynamic data = FlowValueTypeUtility.FlowTypeToPrimitive(value);
 
                 result[cleanedName] = data;
             }

--- a/Graffle.FlowSdk.Services/Extensions/FlowValueTypeUtility.cs
+++ b/Graffle.FlowSdk.Services/Extensions/FlowValueTypeUtility.cs
@@ -1,0 +1,36 @@
+using Graffle.FlowSdk.Types;
+
+namespace Graffle.FlowSdk.Services.Extensions
+{
+    public static class FlowValueTypeUtility
+    {
+        /// <summary>
+        /// Break up a recursive FlowValueType and return an object containing its properties as primitive types (ie not cadence)
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static dynamic FlowTypeToPrimitive(FlowValueType value)
+        {
+            if (FlowValueType.IsCompositeType(value.Type) && value is CompositeType composite)
+            {
+                return composite.FieldsAsDictionary();
+            }
+            else if (value.Type == "Array" && value is ArrayType array)
+            {
+                return array.ToValueData();
+            }
+            else if (value.Type == "Dictionary" && value is DictionaryType dict)
+            {
+                return dict.ConvertToObject();
+            }
+            else if (value.Type == "Optional" && value is OptionalType opt)
+            {
+                return opt.Data == null ? null : FlowTypeToPrimitive(opt.Data); //need to dig into the optional type
+            }
+            else //primitive
+            {
+                return ((dynamic)value).Data; //primitive value, just return the data directly
+            }
+        }
+    }
+}

--- a/Graffle.FlowSdk.Services/Graffle.FlowSdk.Services.csproj
+++ b/Graffle.FlowSdk.Services/Graffle.FlowSdk.Services.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>0.1.42-prerelease</Version>
+    <Version>0.1.43-prerelease</Version>
     <PackageDescription>Sdk and additional services for interacting with the Flow blockchain.</PackageDescription>
     <RepositoryUrl>https://github.com/Graffle/flow-c-sharp-graffle-sdk</RepositoryUrl>
     <Company>Graffle Labs Inc.</Company>


### PR DESCRIPTION
Composite (eg struct), Array, and Dictionary types all have an extension method to recursively break up the constituent data into primitive objects - added support for Optional types here.

Logic was identical in all 3 extension methods so I combined the logic into a single function